### PR TITLE
Fix type casting in parseUrls

### DIFF
--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpTestFrameworkVersionCache">
+    <tools_cache>
+      <tool tool_name="PHPUnit">
+        <cache>
+          <versions>
+            <info id="Local\vendor/autoload.php" version="11.5.2" />
+          </versions>
+        </cache>
+      </tool>
+    </tools_cache>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="LaravelPint">
+    <laravel_pint_settings>
+      <LaravelPintConfiguration tool_path="$PROJECT_DIR$/vendor/bin/pint" />
+    </laravel_pint_settings>
+  </component>
   <component name="MessDetectorOptionsConfiguration">
     <option name="transferred" value="true" />
   </component>
@@ -126,11 +131,29 @@
       <path value="$PROJECT_DIR$/vendor/spatie/laravel-ray" />
       <path value="$PROJECT_DIR$/vendor/guzzlehttp/uri-template" />
       <path value="$PROJECT_DIR$/vendor/laravel/pint" />
+      <path value="$PROJECT_DIR$/vendor/filp/whoops" />
+      <path value="$PROJECT_DIR$/vendor/symfony/clock" />
+      <path value="$PROJECT_DIR$/vendor/league/uri" />
+      <path value="$PROJECT_DIR$/vendor/league/uri-interfaces" />
+      <path value="$PROJECT_DIR$/vendor/carbonphp/carbon-doctrine-types" />
+      <path value="$PROJECT_DIR$/vendor/staabm/side-effects-detector" />
+      <path value="$PROJECT_DIR$/vendor/orchestra/canvas-core" />
+      <path value="$PROJECT_DIR$/vendor/laravel/pail" />
+      <path value="$PROJECT_DIR$/vendor/laravel/tinker" />
+      <path value="$PROJECT_DIR$/vendor/psy/psysh" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php84" />
+      <path value="$PROJECT_DIR$/vendor/nunomaduro/collision" />
+      <path value="$PROJECT_DIR$/vendor/orchestra/canvas" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.4" />
   <component name="PhpStanOptionsConfiguration">
     <option name="transferred" value="true" />
+  </component>
+  <component name="PhpUnit">
+    <phpunit_settings>
+      <PhpUnitSettings custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" phpunit_phar_path="" />
+    </phpunit_settings>
   </component>
   <component name="PsalmOptionsConfiguration">
     <option name="transferred" value="true" />

--- a/.idea/phpunit.xml
+++ b/.idea/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PHPUnit">
+    <option name="directories">
+      <list>
+        <option value="C:\Users\YO\PhpstormProjects\laravel-indexnow\tests" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,8 @@ This version marks the initial launch of the `ymigval/laravel-indexnow` package,
 - Remove composer.lock file from the repository
 
 The composer.lock file was deleted to ensure local dependencies can be managed flexibly without conflicts in different environments. This allows developers to generate the file per their specific setups, accommodating changes in dependency versions.
+
+## 1.0.2 - 2025-01-05
+
+### Fixed
+- Fixed an issue with the parseUrls() method.

--- a/src/IndexNowService.php
+++ b/src/IndexNowService.php
@@ -168,7 +168,7 @@ class IndexNowService
                 throw new NonAbsoluteUrlException();
             }
 
-            $this->urls[$index] = $url->toString();
+            $this->urls[$index] = (string) $url;
         }
     }
 


### PR DESCRIPTION
Replaced type casting of URLs in the parseUrls method. Added necessary PHP and PHPUnit configurations for IDE support, including cache settings, test paths, and project dependencies. Updated CHANGELOG for version 1.0.2 with the fix details.