### PR TITLE
fix: make sure function will be declared only once

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -7,44 +7,37 @@ use Symfony\Component\HttpFoundation\Response as ResponseAlias;
 use Ymigval\LaravelIndexnow\IndexNowApiKeyManager;
 use Ymigval\LaravelIndexnow\LogManager;
 
+if (!function_exists('registerIndexNowKeyRoute')) {
+    /**
+     * Generates the path for the IndexNow API key route.
+     *
+     * @param string $apiKey
+     * @return string
+     */
+    function generateIndexNowKeyRoutePath(string $apiKey): string
+    {
+        return Str::of('/')->append($apiKey)->append('.txt')->toString();
+    }
+    /**
+     * Registers the IndexNow API key route.
+     *
+     * @param string $apiKey
+     */
+    function registerIndexNowKeyRoute(string $apiKey): void
+    {
+        Route::any(generateIndexNowKeyRoutePath($apiKey), function () use ($apiKey) {
+            return new Response($apiKey, ResponseAlias::HTTP_OK, [
+                'Content-Type' => 'text/plain; charset=utf-8',
+            ]);
+        })->name('my_key_index_now');
+    }
 
-/**
- * Content-Type constant for UTF-8 plain text responses.
- */
-const TEXT_PLAIN_UTF8 = 'text/plain; charset=utf-8';
-
-
-try {
-    $apiKey = IndexNowApiKeyManager::fetchOrGenerate();
-    registerKeyRoute($apiKey);
-} catch (Exception $e) {
-    LogManager::addMessage('Error registering IndexNow route: ' . $e->getMessage());
-}
-
-/**
- * Registers the IndexNow API key route.
- *
- * @param string $apiKey
- */
-function registerKeyRoute(string $apiKey): void
-{
-    Route::any(generateKeyRoutePath($apiKey), function () use ($apiKey) {
-        return new Response(
-            $apiKey,
-            ResponseAlias::HTTP_OK,
-            ['Content-Type' => TEXT_PLAIN_UTF8]
+    try {
+        $apiKey = IndexNowApiKeyManager::fetchOrGenerate();
+        registerIndexNowKeyRoute($apiKey);
+    } catch (Exception $e) {
+        LogManager::addMessage(
+            'Error registering IndexNow route: ' . $e->getMessage()
         );
-    })->name('my_key_index_now');
+    }
 }
-
-/**
- * Generates the path for the IndexNow API key route.
- *
- * @param string $apiKey
- * @return string
- */
-function generateKeyRoutePath(string $apiKey): string
-{
-    return Str::of('/')->append($apiKey)->append('.txt')->toString();
-}
-


### PR DESCRIPTION
I have this error on production and can reproduce it when running `sail test` on my project locally. 
`production.ERROR: Cannot redeclare registerKeyRoute() (previously declared in /var/www/site.com/vendor/ymigval/laravel-indexnow/routes/web.php:29) {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Cannot redeclare registerKeyRoute() (previously declared in /var/www/site.com/vendor/ymigval/laravel-indexnow/routes/web.php:29) at /var/www/site.com/vendor/ymigval/laravel-indexnow/routes/web.php:37)`

Honestly, I didn't figure out yet why web.php executing more than once. But in any case, we don't need Fatal Errors when functions on consts defined twice. So, this fix works for me. 